### PR TITLE
Join only with ready nodes

### DIFF
--- a/dag
+++ b/dag
@@ -13,7 +13,7 @@ yel='\033[1;33m'
 blu='\033[1;36m'
 pnk='\033[1;35m'
 clr='\033[0m'
-DAG_VERSION="3.68"
+DAG_VERSION="3.69"
 export updver=$2
 
 function checkDir()

--- a/dag
+++ b/dag
@@ -652,7 +652,7 @@ function doInstall()
                    exit 1
                 fi
 
-                firstIP=$(curl -s $LB:9000/cluster/info | jq -r 'sort_by(.ip.host)[] | .ip.host' | head -n 1)
+                firstIP=$(curl -s $LB:9000/cluster/info | jq -r '.[] | with_entries(select(.ip.status="Ready")) | .ip.host' | sort -uR | head -n 1)
                 if [[ ${#firstIP} -gt 8 ]]; then
                   export GENESIS=$firstIP
                 else


### PR DESCRIPTION
Currently it's possible to end up joining with offline node.
This fixes it by selecting only nodes with "Ready" status from the load balancer response.